### PR TITLE
Fix misspelling causing error when unregistering setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,6 @@ module.exports = class CustomVolumeRange extends Plugin {
 
     pluginWillUnload() {
         uninject('custom-volume-range');
-        powercord.api.settigs.unregisterSettings('custom-volume-range-settings');
+        powercord.api.settings.unregisterSettings('custom-volume-range-settings');
     }
 };


### PR DESCRIPTION
`powercord.api.settigs.unregisterSettings` -> `powercord.api.settings.unregisterSettings`